### PR TITLE
Fix logo + booking + maxQuantity

### DIFF
--- a/src/CommerceBundle/Controller/BookingAdminController.php
+++ b/src/CommerceBundle/Controller/BookingAdminController.php
@@ -88,6 +88,7 @@ class BookingAdminController extends Controller
 	 */
 	public function editBookingAction(Request $request, Evenement $evenement)
 	{
+		$eventDate = $evenement->getDate();
 		//Création des formulaires dans la vue Admin add_Booking
 		$marchandise = new Marchandise();
 		$formEvent = $this->createForm(EvenementType::class, $evenement);
@@ -97,6 +98,14 @@ class BookingAdminController extends Controller
 		if ($request->isXmlHttpRequest())
 		{
 			$em = $this ->getDoctrine()->getManager();
+
+			if ($evenement->getDate() != $eventDate){
+				$users = $em->getRepository(User::class)->findByEvenement($evenement);
+				foreach ($users as $user){
+					$em->remove($user);
+				}
+			}
+
 			$em->persist($evenement);
 			$em->flush();
 

--- a/src/CommerceBundle/Resources/views/user/booking.html.twig
+++ b/src/CommerceBundle/Resources/views/user/booking.html.twig
@@ -64,9 +64,9 @@
 									<td class="col m2 col_table">{{ marchandise.prix }}</td>
 									<td class="col m2 col_table">{{ marchandise.quantite }}</td>
 									<td class="col m2 col_table">{{ marchandise.unite }}</td>
-									<td class="col m2 col_table">
+									<td class="col m2 col_table selectedProductQuantity">
                                         {% if marchandise.quantite > 0 %}
-                                            {{ form_widget(formUser.selectProduits[key].quantiteCommande, {'attr': {'max': marchandise.quantite, 'min': 0 }}) }}
+                                            {{ form_widget(formUser.selectProduits[key].quantiteCommande, {'attr': {'class': 'max_product', 'max': marchandise.quantite, 'min': 0 }}) }}
                                         {% else %}
                                             {{ form_widget(formUser.selectProduits[key].quantiteCommande, {'attr': {'disabled': true, 'placeholder': 'Epuisé' }}) }}
                                         {% endif %}
@@ -116,7 +116,14 @@
 	<script>
 		$("#productReservation").hide();
 
-		$("#validationUser").click(function (e) {
+        $('.max_product').on('change', function(e){
+            if($(this).val() > $(this).attr('max')){
+                Materialize.toast('Veuillez saisir une quantité valide', 4000)
+                $(this).val("");
+            }
+        });
+
+        $("#validationUser").click(function (e) {
 			e.preventDefault();
 
 			var nom = $("#commercebundle_user_nom").val();

--- a/src/CoreBundle/Resources/public/css/main.css
+++ b/src/CoreBundle/Resources/public/css/main.css
@@ -141,8 +141,8 @@ p {
 /* line 148, ../scss/_global.scss */
 .menu-btn:hover .menu_text {
   transition: .5s;
-  color: #00a248;
-  margin: 50px auto 0px -11px;
+  color: black;
+  margin: 55px auto 0px -11px;
   letter-spacing: 2px;
 }
 

--- a/src/CoreBundle/Resources/public/scss/_global.scss
+++ b/src/CoreBundle/Resources/public/scss/_global.scss
@@ -147,8 +147,8 @@ p {
 }
 .menu-btn:hover .menu_text{
     transition: .5s;
-    color: #00a248;
-    margin: 50px auto 0px -11px;
+    color: black;
+    margin: 55px auto 0px -11px;
     letter-spacing: 2px;
 }
 .btn_menu_index{

--- a/src/CoreBundle/Resources/views/layout.html.twig
+++ b/src/CoreBundle/Resources/views/layout.html.twig
@@ -38,7 +38,7 @@
 	{% block menu %}
 		<section class="home home_all">
 			<div class="row open-overlay">
-				<a class="col s1 offset-s10 waves-effect waves-light btn menu-btn">
+				<a class="col s1 offset-s10 menu-btn">
 					<div class="menu_text">Menu</div>
 				</a>
 			</div>


### PR DESCRIPTION
1. AJout d'une vérification en JS que la quantité saisi reste inférieur
ou égal à la quantité max (fix pb IE + Safari)
2. Lors de l'édition d'une commande, si la date est modifié, toutes le
précédentes réservation sont supprimé, sinon la date reste inchangé, les
commande en cours reste présente.
3. Fix du pb d'affichage de logo